### PR TITLE
Plotting map with origin country distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,25 +8,34 @@ What we are trying to "data mining" is:
 - Which departments are the ones who actually select people more often?
 - IDK, propose it!
 
-### data.json
+### data\<year\>.json
 This json contains the placement information of each year
 ```
 {
-    "year": {
-        "participants": {
-            "preselected": <number>,
-            "selected": <number>,
-            "selected-info": {
-                "interviewed": [<number of people who had an interview> , <number of people who hadn't an interview>],
-                "informed": [<number of yes> , <number of no>],
-                "studies": [<undergraduate>, <specialisation>, <master>, <phd>],
-                "japan": [<number of people of have been in japan> , <number of people of haven't been in japan>],
-                "jlpt": [<nothing>, <n1>, <n2>, <n3>, <n4>, <n5>]
-            }
-        },
-        "company name": {
-            "department": [number of vacancies, vacancies filled]
+    "dates": {
+        "start": <str, month or specific date">,
+        "end": <str, month or specific date">,
+        "preselection": <str, month or specific date">,
+        "selection": <str, month or specific date">,
+        "second-round-start": <if there isn't a second round, this key doesn't exists: str, month or specific date">,
+        "second-round-ends": <if there isn't a second round, this key doesn't exists: str, month or specific date">,
+    },
+    "participants": {
+        "preselected": <number>,
+        "selected": <number>,
+        "selected-info": {
+            "countries": {
+                <name of the country>: <number of selected>
+            },
+            "interviewed": [<number of people who had an interview> , <number of people who hadn't an interview>],
+            "informed": [<number of yes> , <number of no>],
+            "studies": [<undergraduate>, <specialisation>, <master>, <phd>],
+            "japan": [<number of people of have been in japan> , <number of people of haven't been in japan>],
+            "jlpt": [<nothing>, <n1>, <n2>, <n3>, <n4>, <n5>]
         }
+    },
+    "company name": {
+        "department": [number of vacancies, vacancies filled]
     }
 }
 ```

--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
     <script type="text/javascript" src="static/js/jquery-3.6.0.min.js" defer></script>
     <script type="text/javascript" src="static/js/script.js" defer></script>
     <script type="text/javascript" src="static/style/bootstrap/js/bootstrap.min.js" defer></script>
+
+    <!-- chartjs -->
+    <script src="https://unpkg.com/chart.js@3.8.0/dist/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-geo@3.8.1/build/index.umd.min.js"></script>
   </head>
 
   <body>
@@ -65,8 +69,10 @@
                       </span>
                   </p>
               </div>
-              <div id="map" class="mb-3">
-              </div>
+              
+              <!-- Map -->
+              <canvas id="map" class="mb-3"></canvas>
+
               <div id="questions" class="mb-3">
                   <h3> Questions to the selected </h3>
                   <div class="mt-4">

--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
     <!-- chartjs -->
     <script src="https://unpkg.com/chart.js@3.8.0/dist/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-geo@3.8.1/build/index.umd.min.js"></script>
+
+    <!-- d3 -->
+    <script src="https://unpkg.com/d3@v6"></script>
+    <script src="https://unpkg.com/d3-composite-projections"></script>
   </head>
 
   <body>

--- a/static/js/data2021.json
+++ b/static/js/data2021.json
@@ -11,6 +11,17 @@
         "preselected": 0,
         "selected": 22,
         "selected-info": {
+            "countries": {
+                "Belgium": 1,
+                "Cyprus": 2,
+                "France": 1,
+                "Germany": 1,
+                "Greece": 1,
+                "Italy": 3,
+                "Poland": 1,
+                "Portugal": 2,
+                "Spain": 6
+            },
             "interviewed": [5, 9],
             "informed": [3, 11],
             "studies": [1, 0, 13, 0],

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,6 +1,44 @@
+function load_map() {
+    fetch('https://unpkg.com/world-atlas/countries-50m.json')
+        .then((r) => r.json())
+        .then((data) => {
+            const countries = ChartGeo.topojson.feature(data, data.objects.countries).features;
+
+            const chart = new Chart(document.getElementById('map').getContext('2d'), {
+                type: 'choropleth',
+                data: {
+                    labels: countries.map((d) => d.properties.name),
+                    datasets: [
+                        {
+                            label: 'Countries',
+                            data: countries.map((d) => ({
+                                feature: d,
+                                value: Math.random(),
+                            })),
+                        },
+                    ],
+                },
+                options: {
+                    showOutline: true,
+                    showGraticule: true,
+                    plugins: {
+                        legend: {
+                            display: false,
+                        },
+                    },
+                    scales: {
+                        xy: {
+                            projection: 'equalEarth',
+                        },
+                    },
+                },
+            });
+        });
+}
+
 function load_year(year) {
-    const path = "https://raw.githubusercontent.com/Gaijins-In-Japan/VulcanusStatistics/main/static/js/data"+year+".json";
-    $.getJSON(path, function(data) {
+    const path = "https://raw.githubusercontent.com/Gaijins-In-Japan/VulcanusStatistics/main/static/js/data" + year + ".json";
+    $.getJSON(path, function (data) {
         // Chart
 
         // Dates
@@ -21,6 +59,7 @@ function load_year(year) {
         }
 
         // Map
+        load_map();
 
         // Questions
         let selected_poll = data['participants']['selected-info'];
@@ -47,13 +86,13 @@ function load_year(year) {
     });
 }
 
-$(document).ready(function() {
+$(document).ready(function () {
 
     let year = $("#pills-tab .nav-link.active").attr("year");
 
     load_year(year);
 
-    $("#pills-tab .nav-link").on("click", function() {
+    $("#pills-tab .nav-link").on("click", function () {
         year = $("this").attr("year");
         load_year(year);
     });

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,8 +1,11 @@
 function load_map() {
-    fetch('https://unpkg.com/world-atlas/countries-50m.json')
+    fetch('https://raw.githubusercontent.com/deldersveld/topojson/master/continents/europe.json')
         .then((r) => r.json())
         .then((data) => {
-            const countries = ChartGeo.topojson.feature(data, data.objects.countries).features;
+            const countries = ChartGeo.topojson.feature(data, data.objects.continent_Europe_subunits).features;
+            const projection = d3.geoConicConformalEurope();
+
+            projection.fitWidth = (size, object) => projection.fitSize([size, 1000], object);
 
             const chart = new Chart(document.getElementById('map').getContext('2d'), {
                 type: 'choropleth',
@@ -11,6 +14,7 @@ function load_map() {
                     datasets: [
                         {
                             label: 'Countries',
+                            outline: countries,
                             data: countries.map((d) => ({
                                 feature: d,
                                 value: Math.random(),
@@ -20,7 +24,7 @@ function load_map() {
                 },
                 options: {
                     showOutline: true,
-                    showGraticule: true,
+                    showGraticule: false,
                     plugins: {
                         legend: {
                             display: false,
@@ -28,7 +32,7 @@ function load_map() {
                     },
                     scales: {
                         xy: {
-                            projection: 'equalEarth',
+                            projection: "mercator",
                         },
                     },
                 },

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,4 +1,4 @@
-function load_map() {
+function load_map(participantsCountries) {
     fetch('https://raw.githubusercontent.com/deldersveld/topojson/master/continents/europe.json')
         .then((r) => r.json())
         .then((data) => {
@@ -10,15 +10,20 @@ function load_map() {
             const chart = new Chart(document.getElementById('map').getContext('2d'), {
                 type: 'choropleth',
                 data: {
-                    labels: countries.map((d) => d.properties.name),
+                    labels: countries.map((d) => d.properties.geounit),
                     datasets: [
                         {
                             label: 'Countries',
                             outline: countries,
-                            data: countries.map((d) => ({
-                                feature: d,
-                                value: Math.random(),
-                            })),
+                            data: countries.map((d) => {
+                                const countryName = d.properties.geounit;
+                                const count = countryName in participantsCountries? participantsCountries[countryName]: 0;
+
+                                return {
+                                    feature: d,
+                                    value: count,
+                                }
+                            }),
                         },
                     ],
                 },
@@ -32,7 +37,7 @@ function load_map() {
                     },
                     scales: {
                         xy: {
-                            projection: "mercator",
+                            projection: "equalEarth",
                         },
                     },
                 },
@@ -41,7 +46,7 @@ function load_map() {
 }
 
 function load_year(year) {
-    const path = "https://raw.githubusercontent.com/Gaijins-In-Japan/VulcanusStatistics/main/static/js/data" + year + ".json";
+    const path = "static/js/data" + year + ".json";
     $.getJSON(path, function (data) {
         // Chart
 
@@ -63,7 +68,7 @@ function load_year(year) {
         }
 
         // Map
-        load_map();
+        load_map(data["participants"]["selected-info"]["countries"]);
 
         // Questions
         let selected_poll = data['participants']['selected-info'];

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,4 +1,5 @@
 function load_map(participantsCountries) {
+
     fetch('https://raw.githubusercontent.com/deldersveld/topojson/master/continents/europe.json')
         .then((r) => r.json())
         .then((data) => {
@@ -46,7 +47,7 @@ function load_map(participantsCountries) {
 }
 
 function load_year(year) {
-    const path = "static/js/data" + year + ".json";
+    const path = "https://raw.githubusercontent.com/Gaijins-In-Japan/VulcanusStatistics/map/static/js/data"+ year +".json";
     $.getJSON(path, function (data) {
         // Chart
 


### PR DESCRIPTION
Added a map chart using `chartjs-chart-geo` showing the origin country distribution of participants.

![localhost_8000_](https://user-images.githubusercontent.com/44172778/180666040-f8d65551-5536-4286-8a80-94ab3ef77fbd.png)

For this purpose, a new `countries` field was created on `data2021.json` and populated with collected data.
Summing the counting for each country only totalizes 18, instead of 22, so some data I couldn't gather is missing.

```jsonc
"participants": {
    "selected-info": {
        "countries": {
            "Belgium": 1,
            "Cyprus": 2,
           // ...
        }
    }
}
```

Additionaly, for some reason the [TopoJSON file](https://raw.githubusercontent.com/deldersveld/topojson/master/continents/europe.json) I'm currently using doesn't seem to consider countries like Turkey and Cyprus as part of Europe, and since those countries are part of VinJ, they should be added manually or a new file should be used.